### PR TITLE
Implémentation gestion des menus et permissions par groupe utilisateur

### DIFF
--- a/admin/gestion_permissions.php
+++ b/admin/gestion_permissions.php
@@ -1,0 +1,65 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php'; // Sera créé plus tard
+
+// TODO: Vérifier si l'utilisateur est admin et authentifié
+
+$page_title = "Gestion des Permissions par Groupe";
+// Inclure l'en-tête
+require_once __DIR__ . '/../includes/header.php';
+?>
+
+<div class="container mt-5 pt-4"> <!-- mt-5 et pt-4 pour espacement avec navbar fixe -->
+    <h1 class="mb-4"><?php echo htmlspecialchars($page_title); ?></h1>
+
+    <p>Interface pour attribuer les permissions sur les traitements aux groupes d'utilisateurs.</p>
+
+    <!-- Zone pour les messages (succès, erreurs) -->
+    <div id="messagesPermissions" class="my-3"></div>
+
+    <div class="row mb-3">
+        <div class="col-md-6 col-lg-4">
+            <label for="selectGroupeUtilisateur" class="form-label">Choisir un Groupe d'Utilisateurs :</label>
+            <select class="form-select" id="selectGroupeUtilisateur">
+                <option selected disabled value="">Sélectionnez un groupe...</option>
+                <!-- Les groupes seront chargés ici par JavaScript -->
+            </select>
+        </div>
+    </div>
+
+    <div id="permissionsContainer" class="mt-4" style="display: none;">
+        <h2>Permissions pour le groupe : <span id="nomGroupeSelectionne"></span></h2>
+        <form id="formPermissions">
+            <input type="hidden" id="selectedGroupeId" name="id_gu">
+            <table class="table table-striped table-hover">
+                <thead>
+                    <tr>
+                        <th>Traitement (Page/Fonctionnalité)</th>
+                        <th>Voir dans Sidebar</th>
+                        <th>Ajouter</th>
+                        <th>Modifier</th>
+                        <th>Supprimer</th>
+                        <th>Imprimer</th>
+                        <th>Exporter</th>
+                        <th>Importer</th>
+                    </tr>
+                </thead>
+                <tbody id="listePermissionsBody">
+                    <!-- Les traitements et leurs permissions seront chargés ici -->
+                </tbody>
+            </table>
+            <button type="submit" class="btn btn-success" id="btnSauvegarderPermissions">Sauvegarder les Permissions</button>
+        </form>
+    </div>
+
+</div>
+
+<?php
+// Inclure le pied de page
+require_once __DIR__ . '/../includes/footer.php';
+// Le script JS spécifique gestion_permissions.js devrait être inclus par footer.php
+// s'il détecte que nous sommes sur la page gestion_permissions.php.
+// Si cette logique n'est pas dans footer.php, décommentez la ligne ci-dessous :
+// echo '<script src="../assets/js/gestion_permissions.js"></script>';
+?>

--- a/admin/gestion_traitements.php
+++ b/admin/gestion_traitements.php
@@ -1,0 +1,101 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php'; // Sera créé plus tard
+
+// TODO: Vérifier si l'utilisateur est admin et authentifié
+
+$page_title = "Gestion des Traitements";
+// Inclure l'en-tête
+require_once __DIR__ . '/../includes/header.php';
+?>
+
+<div class="container mt-5 pt-4"> <!-- mt-5 et pt-4 pour espacement avec navbar fixe -->
+    <h1 class="mb-4"><?php echo htmlspecialchars($page_title); ?></h1>
+
+    <p>Interface pour ajouter, modifier, lister et supprimer les traitements (pages/fonctionnalités) de l'application.</p>
+
+    <!-- Zone pour les messages (succès, erreurs) -->
+    <div id="messages" class="my-3"></div>
+
+    <!-- Bouton pour ajouter un nouveau traitement (ouvre un modal par exemple) -->
+    <button class="btn btn-primary mb-3" id="btnAjouterTraitement" data-bs-toggle="modal" data-bs-target="#traitementModal">
+        <i class="fas fa-plus"></i> Ajouter un Traitement
+    </button>
+
+    <h2 class="mt-4">Liste des Traitements</h2>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Libellé</th>
+                <th>Description</th>
+                <th>URL</th>
+                <th>Icône</th>
+                <th>Ordre</th>
+                <th>Actif</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody id="listeTraitementsBody">
+            <!-- Les traitements seront chargés ici par JavaScript -->
+            <tr>
+                <td colspan="8" class="text-center">Chargement des traitements...</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<!-- Modal pour Ajouter/Modifier un traitement (exemple avec Bootstrap) -->
+<div class="modal fade" id="traitementModal" tabindex="-1" aria-labelledby="traitementModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="traitementModalLabel">Ajouter/Modifier un Traitement</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="formTraitement">
+                    <input type="hidden" id="traitementId" name="id_trait">
+                    <div class="mb-3">
+                        <label for="lib_trait" class="form-label">Libellé du traitement</label>
+                        <input type="text" class="form-control" id="lib_trait" name="lib_trait" required>
+                    </div>
+                    <div class="mb-3">
+                        <label for="description" class="form-label">Description</label>
+                        <textarea class="form-control" id="description" name="description"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="url_traitement" class="form-label">URL</label>
+                        <input type="text" class="form-control" id="url_traitement" name="url_traitement">
+                    </div>
+                    <div class="mb-3">
+                        <label for="icone" class="form-label">Icône (ex: fas fa-home)</label>
+                        <input type="text" class="form-control" id="icone" name="icone" value="fas fa-file">
+                    </div>
+                    <div class="mb-3">
+                        <label for="ordre_affichage" class="form-label">Ordre d'affichage</label>
+                        <input type="number" class="form-control" id="ordre_affichage" name="ordre_affichage" value="0">
+                    </div>
+                    <div class="mb-3 form-check">
+                        <input type="checkbox" class="form-check-input" id="est_actif" name="est_actif" value="1" checked>
+                        <label class="form-check-label" for="est_actif">Actif</label>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+                <button type="submit" class="btn btn-primary" form="formTraitement" id="btnSaveTraitement">Enregistrer</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+// Inclure le pied de page
+require_once __DIR__ . '/../includes/footer.php';
+// Le script JS spécifique gestion_traitements.js devrait être inclus par footer.php
+// s'il détecte que nous sommes sur la page gestion_traitements.php (basé sur $current_script_name).
+// Si cette logique n'est pas dans footer.php, décommentez la ligne ci-dessous :
+// echo '<script src="../assets/js/gestion_traitements.js"></script>';
+?>

--- a/admin/groupe_lister.php
+++ b/admin/groupe_lister.php
@@ -1,0 +1,43 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php';
+
+// Sécurité : Vérifier si l'utilisateur est admin
+/*
+if (!check_user_role(['admin'])) {
+    json_response(false, 'Accès non autorisé.', [], 403);
+    exit;
+}
+*/
+
+$pdo = getPDOConnection();
+
+if (!$pdo) {
+    json_response(false, 'Erreur de connexion à la base de données.');
+    exit;
+}
+
+header('Content-Type: application/json');
+
+try {
+    $stmt = $pdo->query("SELECT id_gu, lib_gu FROM groupe_utilisateur ORDER BY lib_gu ASC");
+    $groupes = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    // S'assurer que id_gu est un entier si nécessaire pour JS, bien que pour un select ce ne soit pas critique.
+    $groupes_typed = array_map(function($groupe) {
+        $groupe['id_gu'] = (int)$groupe['id_gu'];
+        return $groupe;
+    }, $groupes);
+
+    echo json_encode($groupes_typed);
+
+} catch (PDOException $e) {
+    error_log("Erreur PDO lors de la récupération des groupes : " . $e->getMessage());
+    json_response(false, 'Erreur lors de la récupération des groupes d\'utilisateurs.');
+} catch (Exception $e) {
+    error_log("Erreur générale : " . $e->getMessage());
+    json_response(false, 'Une erreur inattendue est survenue.');
+}
+
+?>

--- a/admin/permissions_charger.php
+++ b/admin/permissions_charger.php
@@ -1,0 +1,78 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php';
+
+// Sécurité : Vérifier si l'utilisateur est admin
+/*
+if (!check_user_role(['admin'])) {
+    json_response(false, 'Accès non autorisé.', [], 403);
+    exit;
+}
+*/
+
+$pdo = getPDOConnection();
+
+if (!$pdo) {
+    json_response(false, 'Erreur de connexion à la base de données.');
+    exit;
+}
+
+header('Content-Type: application/json');
+
+$id_gu = filter_input(INPUT_GET, 'id_gu', FILTER_VALIDATE_INT);
+
+if (!$id_gu) {
+    json_response(false, 'ID de groupe utilisateur manquant ou invalide.');
+    exit;
+}
+
+try {
+    // 1. Récupérer tous les traitements actifs (ou tous les traitements, selon la logique métier)
+    // On prend tous les traitements pour pouvoir attribuer/retirer des droits même sur des traitements inactifs globalement.
+    // Le statut 'est_actif' du traitement lui-même est une autre couche de contrôle.
+    $stmt_traitements = $pdo->query("SELECT id_trait, lib_trait FROM traitement ORDER BY ordre_affichage ASC, lib_trait ASC");
+    $traitements = $stmt_traitements->fetchAll(PDO::FETCH_ASSOC);
+
+    // 2. Récupérer les permissions existantes pour ce groupe
+    $stmt_permissions = $pdo->prepare("SELECT * FROM rattacher WHERE id_gu = :id_gu");
+    $stmt_permissions->bindParam(':id_gu', $id_gu, PDO::PARAM_INT);
+    $stmt_permissions->execute();
+    $permissions_raw = $stmt_permissions->fetchAll(PDO::FETCH_ASSOC);
+
+    // Transformer les permissions en un format plus facile à utiliser côté client: [id_trait => {permissions}]
+    $permissions_map = [];
+    foreach ($permissions_raw as $perm) {
+        $id_traitement_key = (int)$perm['id_traitement'];
+        $permissions_map[$id_traitement_key] = [
+            'voir_dans_sidebar' => (bool)$perm['voir_dans_sidebar'],
+            'peut_ajouter'      => (bool)$perm['peut_ajouter'],
+            'peut_modifier'     => (bool)$perm['peut_modifier'],
+            'peut_supprimer'    => (bool)$perm['peut_supprimer'],
+            'peut_imprimer'     => (bool)$perm['peut_imprimer'],
+            'peut_exporter'     => (bool)$perm['peut_exporter'],
+            'peut_importer'     => (bool)$perm['peut_importer'],
+        ];
+    }
+
+    // S'assurer que id_trait est un entier pour les traitements
+    $traitements_typed = array_map(function($trait) {
+        $trait['id_trait'] = (int)$trait['id_trait'];
+        return $trait;
+    }, $traitements);
+
+
+    echo json_encode([
+        'traitements' => $traitements_typed,
+        'permissions' => $permissions_map
+    ]);
+
+} catch (PDOException $e) {
+    error_log("Erreur PDO lors du chargement des permissions : " . $e->getMessage());
+    json_response(false, 'Erreur lors du chargement des permissions pour le groupe.');
+} catch (Exception $e) {
+    error_log("Erreur générale : " . $e->getMessage());
+    json_response(false, 'Une erreur inattendue est survenue.');
+}
+
+?>

--- a/admin/permissions_sauvegarder.php
+++ b/admin/permissions_sauvegarder.php
@@ -1,0 +1,122 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php';
+
+// Sécurité : Vérifier si l'utilisateur est admin et si la requête est POST
+/*
+if (!check_user_role(['admin'])) {
+    json_response(false, 'Accès non autorisé.', [], 403);
+    exit;
+}
+*/
+if (!is_post_request()) {
+    json_response(false, 'Méthode non autorisée.', [], 405);
+    exit;
+}
+
+$pdo = getPDOConnection();
+if (!$pdo) {
+    json_response(false, 'Erreur de connexion à la base de données.');
+    exit;
+}
+
+// Récupération des données
+$id_gu = filter_input(INPUT_POST, 'id_gu', FILTER_VALIDATE_INT);
+// Les permissions sont attendues sous la forme d'un tableau: $_POST['permissions'][id_trait][nom_permission]
+$permissions_post = $_POST['permissions'] ?? [];
+
+if (!$id_gu) {
+    json_response(false, 'ID de groupe utilisateur manquant ou invalide.');
+    exit;
+}
+
+// Valider que $permissions_post est bien un tableau
+if (!is_array($permissions_post)) {
+    json_response(false, 'Format de données de permissions incorrect.');
+    exit;
+}
+
+// Liste des clés de permission attendues pour chaque traitement
+$permission_keys = [
+    'voir_dans_sidebar', 'peut_ajouter', 'peut_modifier', 'peut_supprimer',
+    'peut_imprimer', 'peut_exporter', 'peut_importer'
+];
+
+try {
+    $pdo->beginTransaction();
+
+    // 1. Supprimer toutes les permissions existantes pour ce groupe
+    $stmt_delete = $pdo->prepare("DELETE FROM rattacher WHERE id_gu = :id_gu");
+    $stmt_delete->bindParam(':id_gu', $id_gu, PDO::PARAM_INT);
+    $stmt_delete->execute();
+
+    // 2. Préparer la requête d'insertion pour les nouvelles permissions
+    $sql_insert = "INSERT INTO rattacher (id_gu, id_traitement, voir_dans_sidebar, peut_ajouter, peut_modifier, peut_supprimer, peut_imprimer, peut_exporter, peut_importer)
+                   VALUES (:id_gu, :id_traitement, :voir_dans_sidebar, :peut_ajouter, :peut_modifier, :peut_supprimer, :peut_imprimer, :peut_exporter, :peut_importer)";
+    $stmt_insert = $pdo->prepare($sql_insert);
+
+    // 3. Parcourir les permissions envoyées et les insérer
+    // $permissions_post est de la forme [id_trait => [nom_perm => 'on', ...]] si checkbox cochée
+    // ou [id_trait => []] si aucune checkbox n'est cochée pour ce traitement.
+    // Le JS devrait envoyer les clés même si non cochées (avec une valeur falsy), ou alors il faut ajuster ici.
+    // Le JS actuel envoie seulement les 'on' si cochées.
+    // On va donc récupérer la liste de tous les traitements pour s'assurer de créer une entrée pour chacun, même si toutes les perms sont à false.
+
+    $stmt_all_traitements = $pdo->query("SELECT id_trait FROM traitement");
+    $all_traitements_ids = $stmt_all_traitements->fetchAll(PDO::FETCH_COLUMN);
+
+    foreach ($all_traitements_ids as $id_trait_from_db) {
+        $id_trait = (int)$id_trait_from_db; // S'assurer que c'est un entier
+        $perms_for_trait = $permissions_post[$id_trait] ?? []; // Permissions envoyées pour ce traitement
+
+        $params = [
+            'id_gu' => $id_gu,
+            'id_traitement' => $id_trait
+        ];
+
+        $has_any_permission = false; // Pour savoir si on doit insérer une ligne
+
+        foreach ($permission_keys as $key) {
+            // Si la clé existe dans $perms_for_trait (c'est-à-dire checkbox cochée et envoyée), alors TRUE (1)
+            // Sinon, FALSE (0)
+            $params[$key] = isset($perms_for_trait[$key]) ? 1 : 0;
+            if ($params[$key] == 1) {
+                $has_any_permission = true;
+            }
+        }
+
+        // On insère une ligne dans rattacher seulement si au moins une permission est accordée
+        // OU si on veut explicitement une ligne "tout à false" pour chaque traitement pour un groupe.
+        // La logique actuelle du JS (gestion_permissions.js) construit le tableau des permissions
+        // dynamiquement, donc si un traitement n'a aucune case cochée, il n'apparaîtra pas dans $_POST['permissions'][$id_trait].
+        // Pour simplifier, on insère une ligne pour chaque traitement qui a au moins une permission cochée.
+        // Si aucune permission n'est cochée pour un traitement, aucune ligne ne sera insérée pour ce id_trait/id_gu.
+        // C'est équivalent à "pas de droit".
+
+        // Ajustement: le JS envoie `permissions[ID_TRAIT][NOM_PERM]` qui sera 'on' si coché.
+        // Donc, $perms_for_trait[$key] sera 'on'. On convertit en booléen (0 ou 1).
+
+        if ($has_any_permission) { // Ou si on veut toujours une ligne, on retire cette condition
+             $stmt_insert->execute($params);
+        }
+    }
+
+    $pdo->commit();
+    json_response(true, 'Permissions sauvegardées avec succès.');
+
+} catch (PDOException $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    error_log("Erreur PDO lors de la sauvegarde des permissions : " . $e->getMessage());
+    json_response(false, 'Erreur de base de données lors de la sauvegarde des permissions. ' . $e->getMessage());
+} catch (Exception $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    error_log("Erreur générale lors de la sauvegarde des permissions : " . $e->getMessage());
+    json_response(false, 'Une erreur inattendue est survenue lors de la sauvegarde des permissions.');
+}
+
+?>

--- a/admin/traitement_ajouter.php
+++ b/admin/traitement_ajouter.php
@@ -1,0 +1,81 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php';
+
+// Sécurité : Vérifier si l'utilisateur est admin et si la requête est POST
+/*
+if (!check_user_role(['admin'])) {
+    json_response(false, 'Accès non autorisé.', [], 403);
+    exit;
+}
+*/
+if (!is_post_request()) {
+    json_response(false, 'Méthode non autorisée.', [], 405);
+    exit;
+}
+
+$pdo = getPDOConnection();
+if (!$pdo) {
+    json_response(false, 'Erreur de connexion à la base de données.');
+    exit;
+}
+
+// Récupération et validation des données du formulaire
+$lib_trait = sanitize_input($_POST['lib_trait'] ?? null);
+$description = sanitize_input($_POST['description'] ?? null); // Peut être vide
+$url_traitement = sanitize_input($_POST['url_traitement'] ?? null); // Peut être vide
+$icone = sanitize_input($_POST['icone'] ?? 'fas fa-file');
+$ordre_affichage = filter_input(INPUT_POST, 'ordre_affichage', FILTER_VALIDATE_INT);
+// Pour la checkbox 'est_actif', si elle n'est pas cochée, elle n'est pas envoyée.
+// Le JS s'assure d'envoyer '0' ou '1'. Sinon, on peut faire :
+$est_actif = isset($_POST['est_actif']) ? (int)$_POST['est_actif'] : 0;
+if ($est_actif !== 0 && $est_actif !== 1) { // S'assurer que c'est bien 0 ou 1
+    $est_actif = 0;
+}
+
+
+// Validation simple
+if (empty($lib_trait)) {
+    json_response(false, 'Le libellé du traitement est requis.');
+    exit;
+}
+if ($ordre_affichage === false || $ordre_affichage < 0) { // false si non entier ou invalide
+    $ordre_affichage = 0; // Valeur par défaut si invalide
+}
+
+
+try {
+    $sql = "INSERT INTO traitement (lib_trait, description, url_traitement, icone, ordre_affichage, est_actif, date_creation)
+            VALUES (:lib_trait, :description, :url_traitement, :icone, :ordre_affichage, :est_actif, CURRENT_TIMESTAMP)";
+
+    $stmt = $pdo->prepare($sql);
+
+    $stmt->bindParam(':lib_trait', $lib_trait, PDO::PARAM_STR);
+    $stmt->bindParam(':description', $description, PDO::PARAM_STR);
+    $stmt->bindParam(':url_traitement', $url_traitement, PDO::PARAM_STR);
+    $stmt->bindParam(':icone', $icone, PDO::PARAM_STR);
+    $stmt->bindParam(':ordre_affichage', $ordre_affichage, PDO::PARAM_INT);
+    $stmt->bindParam(':est_actif', $est_actif, PDO::PARAM_INT); // Stocké comme TINYINT(1)
+
+    if ($stmt->execute()) {
+        $new_id = $pdo->lastInsertId();
+        json_response(true, 'Traitement ajouté avec succès.', ['id_trait' => $new_id]);
+    } else {
+        json_response(false, 'Erreur lors de l\'ajout du traitement.');
+    }
+
+} catch (PDOException $e) {
+    error_log("Erreur PDO lors de l'ajout : " . $e->getMessage());
+    // Vérifier les erreurs de contrainte unique, etc.
+    if ($e->getCode() == '23000') { // Code d'erreur SQL pour violation de contrainte (ex: libellé unique)
+        json_response(false, 'Un traitement avec ce libellé existe peut-être déjà.');
+    } else {
+        json_response(false, 'Erreur de base de données lors de l\'ajout du traitement. Message: ' . $e->getMessage());
+    }
+} catch (Exception $e) {
+    error_log("Erreur générale lors de l'ajout : " . $e->getMessage());
+    json_response(false, 'Une erreur inattendue est survenue lors de l\'ajout.');
+}
+
+?>

--- a/admin/traitement_lister.php
+++ b/admin/traitement_lister.php
@@ -1,0 +1,70 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php';
+
+// Sécurité : Vérifier si l'utilisateur est admin (à implémenter correctement)
+/*
+if (!check_user_role(['admin'])) {
+    json_response(false, 'Accès non autorisé.', [], 403);
+    exit;
+}
+*/
+
+$pdo = getPDOConnection();
+
+if (!$pdo) {
+    json_response(false, 'Erreur de connexion à la base de données.');
+    exit;
+}
+
+header('Content-Type: application/json');
+
+try {
+    // Si un ID est fourni, retourner un seul traitement (pour la modification)
+    if (isset($_GET['id'])) {
+        $id_trait = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+        if (!$id_trait) {
+            json_response(false, 'ID de traitement invalide.');
+            exit;
+        }
+
+        $stmt = $pdo->prepare("SELECT * FROM traitement WHERE id_trait = :id_trait");
+        $stmt->bindParam(':id_trait', $id_trait, PDO::PARAM_INT);
+        $stmt->execute();
+        $traitement = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        if ($traitement) {
+            // Assurer que les valeurs numériques sont bien des nombres et booléen pour est_actif
+            $traitement['id_trait'] = (int)$traitement['id_trait'];
+            $traitement['ordre_affichage'] = (int)$traitement['ordre_affichage'];
+            $traitement['est_actif'] = (bool)$traitement['est_actif'];
+            echo json_encode($traitement); // Retourne directement l'objet traitement
+        } else {
+            json_response(false, 'Traitement non trouvé.');
+        }
+    } else {
+        // Sinon, retourner tous les traitements
+        $stmt = $pdo->query("SELECT * FROM traitement ORDER BY ordre_affichage ASC, lib_trait ASC");
+        $traitements = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        // S'assurer que les types sont corrects pour le JS
+        $traitements_typed = array_map(function($trait) {
+            $trait['id_trait'] = (int)$trait['id_trait'];
+            $trait['ordre_affichage'] = (int)$trait['ordre_affichage'];
+            $trait['est_actif'] = (bool)$trait['est_actif']; // ou (int) si vous préférez 0/1
+            return $trait;
+        }, $traitements);
+
+        echo json_encode($traitements_typed);
+    }
+
+} catch (PDOException $e) {
+    error_log("Erreur PDO : " . $e->getMessage()); // Log l'erreur côté serveur
+    json_response(false, 'Erreur lors de la récupération des traitements. Veuillez consulter les logs du serveur.');
+} catch (Exception $e) {
+    error_log("Erreur : " . $e->getMessage());
+    json_response(false, 'Une erreur inattendue est survenue.');
+}
+
+?>

--- a/admin/traitement_modifier.php
+++ b/admin/traitement_modifier.php
@@ -1,0 +1,103 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php';
+
+// Sécurité : Vérifier si l'utilisateur est admin et si la requête est POST
+/*
+if (!check_user_role(['admin'])) {
+    json_response(false, 'Accès non autorisé.', [], 403);
+    exit;
+}
+*/
+if (!is_post_request()) {
+    json_response(false, 'Méthode non autorisée.', [], 405);
+    exit;
+}
+
+$pdo = getPDOConnection();
+if (!$pdo) {
+    json_response(false, 'Erreur de connexion à la base de données.');
+    exit;
+}
+
+// Récupération et validation des données du formulaire
+$id_trait = filter_input(INPUT_POST, 'id_trait', FILTER_VALIDATE_INT); // 'id_trait' vient du champ hidden
+$lib_trait = sanitize_input($_POST['lib_trait'] ?? null);
+$description = sanitize_input($_POST['description'] ?? null);
+$url_traitement = sanitize_input($_POST['url_traitement'] ?? null);
+$icone = sanitize_input($_POST['icone'] ?? 'fas fa-file');
+$ordre_affichage = filter_input(INPUT_POST, 'ordre_affichage', FILTER_VALIDATE_INT);
+$est_actif = isset($_POST['est_actif']) ? (int)$_POST['est_actif'] : 0;
+if ($est_actif !== 0 && $est_actif !== 1) {
+    $est_actif = 0;
+}
+
+
+// Validation
+if (!$id_trait) {
+    json_response(false, 'ID de traitement invalide ou manquant.');
+    exit;
+}
+if (empty($lib_trait)) {
+    json_response(false, 'Le libellé du traitement est requis.');
+    exit;
+}
+if ($ordre_affichage === false || $ordre_affichage < 0) {
+    $ordre_affichage = 0; // Valeur par défaut
+}
+
+
+try {
+    // Vérifier si le traitement existe avant de le modifier
+    $stmt_check = $pdo->prepare("SELECT id_trait FROM traitement WHERE id_trait = :id_trait");
+    $stmt_check->bindParam(':id_trait', $id_trait, PDO::PARAM_INT);
+    $stmt_check->execute();
+    if ($stmt_check->fetchColumn() === false) {
+        json_response(false, "Le traitement avec l'ID $id_trait n'existe pas.");
+        exit;
+    }
+
+    $sql = "UPDATE traitement SET
+                lib_trait = :lib_trait,
+                description = :description,
+                url_traitement = :url_traitement,
+                icone = :icone,
+                ordre_affichage = :ordre_affichage,
+                est_actif = :est_actif
+            WHERE id_trait = :id_trait";
+
+    $stmt = $pdo->prepare($sql);
+
+    $stmt->bindParam(':id_trait', $id_trait, PDO::PARAM_INT);
+    $stmt->bindParam(':lib_trait', $lib_trait, PDO::PARAM_STR);
+    $stmt->bindParam(':description', $description, PDO::PARAM_STR);
+    $stmt->bindParam(':url_traitement', $url_traitement, PDO::PARAM_STR);
+    $stmt->bindParam(':icone', $icone, PDO::PARAM_STR);
+    $stmt->bindParam(':ordre_affichage', $ordre_affichage, PDO::PARAM_INT);
+    $stmt->bindParam(':est_actif', $est_actif, PDO::PARAM_INT);
+
+    if ($stmt->execute()) {
+        if ($stmt->rowCount() > 0) {
+            json_response(true, 'Traitement modifié avec succès.');
+        } else {
+            // Aucune ligne affectée, soit les données étaient identiques, soit l'ID n'existait pas (déjà vérifié)
+            json_response(true, 'Aucune modification détectée pour le traitement.');
+        }
+    } else {
+        json_response(false, 'Erreur lors de la modification du traitement.');
+    }
+
+} catch (PDOException $e) {
+    error_log("Erreur PDO lors de la modification : " . $e->getMessage());
+    if ($e->getCode() == '23000') {
+        json_response(false, 'Un traitement avec ce libellé existe peut-être déjà (autre que celui-ci).');
+    } else {
+        json_response(false, 'Erreur de base de données lors de la modification. Message: ' . $e->getMessage());
+    }
+} catch (Exception $e) {
+    error_log("Erreur générale lors de la modification : " . $e->getMessage());
+    json_response(false, 'Une erreur inattendue est survenue lors de la modification.');
+}
+
+?>

--- a/admin/traitement_supprimer.php
+++ b/admin/traitement_supprimer.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../core/db_connect.php';
+require_once __DIR__ . '/../core/functions.php';
+
+// Sécurité : Vérifier si l'utilisateur est admin et si la requête est POST
+/*
+if (!check_user_role(['admin'])) {
+    json_response(false, 'Accès non autorisé.', [], 403);
+    exit;
+}
+*/
+if (!is_post_request()) {
+    json_response(false, 'Méthode non autorisée.', [], 405);
+    exit;
+}
+
+$pdo = getPDOConnection();
+if (!$pdo) {
+    json_response(false, 'Erreur de connexion à la base de données.');
+    exit;
+}
+
+// Récupération et validation de l'ID du traitement à supprimer
+$id_trait = filter_input(INPUT_POST, 'id_trait', FILTER_VALIDATE_INT);
+
+if (!$id_trait) {
+    json_response(false, 'ID de traitement invalide ou manquant.');
+    exit;
+}
+
+try {
+    // Avant de supprimer, on pourrait vérifier si le traitement existe,
+    // mais DELETE ne lèvera pas d'erreur si l'ID n'existe pas, il affectera juste 0 lignes.
+    // Cependant, cela peut être utile pour un message plus précis.
+    $stmt_check = $pdo->prepare("SELECT id_trait FROM traitement WHERE id_trait = :id_trait");
+    $stmt_check->bindParam(':id_trait', $id_trait, PDO::PARAM_INT);
+    $stmt_check->execute();
+    if ($stmt_check->fetchColumn() === false) {
+        json_response(false, "Le traitement avec l'ID $id_trait n'existe pas et ne peut être supprimé.");
+        exit;
+    }
+
+    // La suppression des entrées correspondantes dans la table `rattacher`
+    // devrait être gérée par la contrainte FOREIGN KEY `ON DELETE CASCADE`
+    // si elle a été définie lors de la création de la table `rattacher`.
+    // Si ce n'est pas le cas, il faudrait d'abord supprimer manuellement les entrées dans `rattacher`.
+    // Exemple de suppression manuelle (si pas de CASCADE):
+    /*
+    $stmt_rattacher = $pdo->prepare("DELETE FROM rattacher WHERE id_traitement = :id_traitement");
+    $stmt_rattacher->bindParam(':id_traitement', $id_trait, PDO::PARAM_INT);
+    $stmt_rattacher->execute();
+    */
+
+    $sql = "DELETE FROM traitement WHERE id_trait = :id_trait";
+    $stmt = $pdo->prepare($sql);
+    $stmt->bindParam(':id_trait', $id_trait, PDO::PARAM_INT);
+
+    if ($stmt->execute()) {
+        if ($stmt->rowCount() > 0) {
+            json_response(true, 'Traitement supprimé avec succès.');
+        } else {
+            // Cela ne devrait pas arriver si la vérification précédente a été faite.
+            json_response(false, 'Aucun traitement trouvé avec cet ID pour la suppression (ou déjà supprimé).');
+        }
+    } else {
+        json_response(false, 'Erreur lors de la suppression du traitement.');
+    }
+
+} catch (PDOException $e) {
+    error_log("Erreur PDO lors de la suppression : " . $e->getMessage());
+    // Si une contrainte de clé étrangère empêche la suppression (par exemple, si ON DELETE CASCADE n'est pas défini
+    // et qu'il y a des références dans `rattacher` ou ailleurs).
+    if ($e->getCode() == '23000') {
+        json_response(false, 'Impossible de supprimer ce traitement car il est référencé ailleurs (par exemple, dans des permissions de groupe). Veuillez d\'abord supprimer ces références.');
+    } else {
+        json_response(false, 'Erreur de base de données lors de la suppression. Message: ' . $e->getMessage());
+    }
+} catch (Exception $e) {
+    error_log("Erreur générale lors de la suppression : " . $e->getMessage());
+    json_response(false, 'Une erreur inattendue est survenue lors de la suppression.');
+}
+
+?>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,219 @@
+/* Styles globaux pour le projet */
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+.container {
+    width: 80%;
+    margin: auto;
+    overflow: hidden;
+    padding: 0 20px;
+}
+
+/* Header (si vous en avez un simple) */
+header {
+    background: #333;
+    color: #fff;
+    padding-top: 30px;
+    min-height: 70px;
+    border-bottom: #0779e4 3px solid;
+}
+
+header a {
+    color: #fff;
+    text-decoration: none;
+    text-transform: uppercase;
+    font-size: 16px;
+}
+
+header ul {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    float: right;
+}
+
+header li {
+    display: inline;
+    padding: 0 20px 0 20px;
+}
+
+header #branding {
+    float: left;
+}
+
+header #branding h1 {
+    margin: 0;
+}
+
+/* Styles pour les formulaires */
+.form-label {
+    font-weight: bold;
+}
+
+.btn {
+    padding: 10px 15px;
+    border: none;
+    cursor: pointer;
+    border-radius: 5px;
+}
+
+.btn-primary {
+    background-color: #007bff;
+    color: white;
+}
+.btn-primary:hover {
+    background-color: #0056b3;
+}
+
+.btn-secondary {
+    background-color: #6c757d;
+    color: white;
+}
+.btn-secondary:hover {
+    background-color: #545b62;
+}
+
+.btn-success {
+    background-color: #28a745;
+    color: white;
+}
+.btn-success:hover {
+    background-color: #1e7e34;
+}
+
+.btn-danger {
+    background-color: #dc3545;
+    color: white;
+}
+.btn-danger:hover {
+    background-color: #b02a37;
+}
+
+.btn-warning {
+    background-color: #ffc107;
+    color: #212529;
+}
+.btn-warning:hover {
+    background-color: #d39e00;
+}
+
+
+/* Tableaux */
+.table {
+    width: 100%;
+    margin-bottom: 1rem;
+    color: #212529;
+    border-collapse: collapse;
+}
+
+.table th,
+.table td {
+    padding: 0.75rem;
+    vertical-align: top;
+    border-top: 1px solid #dee2e6;
+}
+
+.table thead th {
+    vertical-align: bottom;
+    border-bottom: 2px solid #dee2e6;
+    background-color: #e9ecef;
+}
+
+.table-striped tbody tr:nth-of-type(odd) {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.table-hover tbody tr:hover {
+    background-color: rgba(0, 0, 0, 0.075);
+}
+
+/* Modals (si vous utilisez Bootstrap, ces styles peuvent être ajustés ou complétés) */
+.modal-header {
+    border-bottom: 1px solid #dee2e6;
+}
+.modal-footer {
+    border-top: 1px solid #dee2e6;
+}
+
+
+/* Messages de feedback */
+#messages, #messagesPermissions {
+    padding: 10px;
+    margin-bottom: 15px;
+    border-radius: 5px;
+}
+.alert-success {
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+}
+.alert-danger {
+    color: #721c24;
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+}
+.alert-info {
+    color: #0c5460;
+    background-color: #d1ecf1;
+    border-color: #bee5eb;
+}
+
+/* Sidebar (structure de base) */
+.sidebar {
+    width: 250px;
+    background: #333;
+    color: #fff;
+    padding: 15px;
+    /* Ajouter d'autres styles pour la position, hauteur, etc. */
+}
+.sidebar ul {
+    list-style: none;
+    padding: 0;
+}
+.sidebar ul li a {
+    color: #fff;
+    text-decoration: none;
+    display: block;
+    padding: 10px 15px;
+    border-bottom: 1px #444 dotted;
+}
+.sidebar ul li a:hover {
+    background: #555;
+}
+.sidebar ul li a .fas { /* Pour les icônes FontAwesome */
+    margin-right: 10px;
+}
+
+/* Utilitaires */
+.mt-4 {
+    margin-top: 1.5rem !important;
+}
+.mb-3 {
+    margin-bottom: 1rem !important;
+}
+.text-center {
+    text-align: center !important;
+}
+
+/* Responsive (exemple simple) */
+@media(max-width: 768px){
+    header #branding,
+    header nav,
+    header nav li,
+    .container {
+        float: none;
+        text-align: center;
+        width: 100%;
+    }
+    .sidebar {
+        width: 100%;
+        /* Ajuster pour un affichage mobile, peut-être un menu burger */
+    }
+}
+?>

--- a/assets/js/gestion_permissions.js
+++ b/assets/js/gestion_permissions.js
@@ -1,0 +1,163 @@
+document.addEventListener('DOMContentLoaded', function () {
+
+    // Fonctions d'échappement HTML simples pour la sécurité XSS de base côté client
+    function escapeHTML(str) {
+        if (str === null || typeof str === 'undefined') return '';
+        return String(str).replace(/[&<>"']/g, function (match) {
+            return {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            }[match];
+        });
+    }
+
+    // Note: escapeAttribute n'est pas directement utilisé ici car on coche des checkboxes,
+    // mais c'est bon de l'avoir si on ajoutait des attributs dynamiques.
+
+    const selectGroupeUtilisateur = document.getElementById('selectGroupeUtilisateur');
+    const permissionsContainer = document.getElementById('permissionsContainer');
+    const listePermissionsBody = document.getElementById('listePermissionsBody');
+    const nomGroupeSelectionneSpan = document.getElementById('nomGroupeSelectionne');
+    const formPermissions = document.getElementById('formPermissions');
+    const messagesPermissionsDiv = document.getElementById('messagesPermissions');
+    const selectedGroupeIdField = document.getElementById('selectedGroupeId');
+
+    // Fonction pour afficher les messages
+    function afficherMessagePermissions(message, type = 'info') {
+        messagesPermissionsDiv.innerHTML = `<div class="alert alert-${type}" role="alert">${message}</div>`;
+        setTimeout(() => { messagesPermissionsDiv.innerHTML = ''; }, 5000);
+    }
+
+    // Charger les groupes d'utilisateurs au chargement de la page
+    async function chargerGroupesUtilisateurs() {
+        try {
+            // Remplacer par l'URL correcte du script PHP qui liste les groupes
+            // Ce script PHP devra être créé. Ex: 'groupe_lister.php'
+            const response = await fetch('groupe_lister.php');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const groupes = await response.json();
+
+            selectGroupeUtilisateur.innerHTML = '<option selected disabled value="">Sélectionnez un groupe...</option>'; // Reset
+            if (groupes.length > 0) {
+                groupes.forEach(groupe => {
+                    const option = document.createElement('option');
+                    option.value = groupe.id_gu;
+                    option.textContent = groupe.lib_gu;
+                    selectGroupeUtilisateur.appendChild(option);
+                });
+            } else {
+                 selectGroupeUtilisateur.innerHTML = '<option selected disabled value="">Aucun groupe trouvé</option>';
+            }
+        } catch (error) {
+            console.error('Erreur lors du chargement des groupes:', error);
+            selectGroupeUtilisateur.innerHTML = '<option selected disabled value="">Erreur chargement</option>';
+            afficherMessagePermissions('Erreur lors du chargement des groupes.', 'danger');
+        }
+    }
+
+    // Charger les permissions pour le groupe sélectionné
+    async function chargerPermissionsPourGroupe(id_gu, nom_gu) {
+        if (!id_gu) {
+            permissionsContainer.style.display = 'none';
+            return;
+        }
+
+        selectedGroupeIdField.value = id_gu;
+        nomGroupeSelectionneSpan.textContent = nom_gu;
+        permissionsContainer.style.display = 'block';
+        listePermissionsBody.innerHTML = '<tr><td colspan="8" class="text-center">Chargement des permissions...</td></tr>';
+
+        try {
+            // Remplacer par l'URL correcte du script PHP qui charge les permissions pour un groupe
+            // Ce script PHP devra être créé. Ex: 'permissions_charger.php'
+            const response = await fetch(`permissions_charger.php?id_gu=${id_gu}`);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const data = await response.json(); // Attend un objet {traitements: [], permissions: {}}
+
+            listePermissionsBody.innerHTML = ''; // Vider le tableau
+
+            if (data.traitements && data.traitements.length > 0) {
+                data.traitements.forEach(trait => {
+                    const perm = data.permissions[trait.id_trait] || {}; // Permissions pour ce traitement
+                    const row = listePermissionsBody.insertRow();
+                    // Le libellé du traitement est la seule donnée dynamique affichée ici.
+                    // Les noms des permissions sont fixes.
+                    row.innerHTML = `
+                        <td>${escapeHTML(trait.lib_trait)} (ID: ${trait.id_trait})</td>
+                        <td><input type="checkbox" class="form-check-input" name="permissions[${trait.id_trait}][voir_dans_sidebar]" ${perm.voir_dans_sidebar ? 'checked' : ''}></td>
+                        <td><input type="checkbox" class="form-check-input" name="permissions[${trait.id_trait}][peut_ajouter]" ${perm.peut_ajouter ? 'checked' : ''}></td>
+                        <td><input type="checkbox" class="form-check-input" name="permissions[${trait.id_trait}][peut_modifier]" ${perm.peut_modifier ? 'checked' : ''}></td>
+                        <td><input type="checkbox" class="form-check-input" name="permissions[${trait.id_trait}][peut_supprimer]" ${perm.peut_supprimer ? 'checked' : ''}></td>
+                        <td><input type="checkbox" class="form-check-input" name="permissions[${trait.id_trait}][peut_imprimer]" ${perm.peut_imprimer ? 'checked' : ''}></td>
+                        <td><input type="checkbox" class="form-check-input" name="permissions[${trait.id_trait}][peut_exporter]" ${perm.peut_exporter ? 'checked' : ''}></td>
+                        <td><input type="checkbox" class="form-check-input" name="permissions[${trait.id_trait}][peut_importer]" ${perm.peut_importer ? 'checked' : ''}></td>
+                    `;
+                });
+            } else {
+                listePermissionsBody.innerHTML = '<tr><td colspan="8" class="text-center">Aucun traitement à configurer. Veuillez d\'abord ajouter des traitements.</td></tr>';
+            }
+        } catch (error) {
+            console.error('Erreur lors du chargement des permissions:', error);
+            listePermissionsBody.innerHTML = '<tr><td colspan="8" class="text-center">Erreur lors du chargement des permissions.</td></tr>';
+            afficherMessagePermissions('Erreur lors du chargement des permissions.', 'danger');
+        }
+    }
+
+    // Écouteur pour le changement de groupe sélectionné
+    if (selectGroupeUtilisateur) {
+        selectGroupeUtilisateur.addEventListener('change', function () {
+            const selectedOption = this.options[this.selectedIndex];
+            chargerPermissionsPourGroupe(this.value, selectedOption.text);
+        });
+    }
+
+    // Soumission du formulaire de permissions
+    if (formPermissions) {
+        formPermissions.addEventListener('submit', async function (e) {
+            e.preventDefault();
+            const formData = new FormData(formPermissions);
+            const id_gu = selectedGroupeIdField.value;
+            if (!id_gu) {
+                afficherMessagePermissions('Aucun groupe sélectionné.', 'danger');
+                return;
+            }
+            // formData.append('id_gu', id_gu); // Déjà dans le formulaire via input hidden
+
+            try {
+                // Remplacer par l'URL correcte du script PHP qui sauvegarde les permissions
+                // Ce script PHP devra être créé. Ex: 'permissions_sauvegarder.php'
+                const response = await fetch('permissions_sauvegarder.php', {
+                    method: 'POST',
+                    body: formData
+                });
+
+                if (!response.ok) {
+                    const errorText = await response.text();
+                    throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`);
+                }
+
+                const result = await response.json();
+                if (result.success) {
+                    afficherMessagePermissions(result.message || 'Permissions sauvegardées avec succès!', 'success');
+                    // Optionnel: Recharger les permissions pour voir les changements (si la sauvegarde ne retourne pas tout)
+                    // chargerPermissionsPourGroupe(id_gu, nomGroupeSelectionneSpan.textContent);
+                } else {
+                    afficherMessagePermissions(result.message || 'Erreur lors de la sauvegarde des permissions.', 'danger');
+                }
+            } catch (error) {
+                console.error('Erreur lors de la sauvegarde des permissions:', error);
+                afficherMessagePermissions(`Erreur: ${error.message}`, 'danger');
+            }
+        });
+    }
+
+    // Initialisation
+    chargerGroupesUtilisateurs();
+});

--- a/assets/js/gestion_traitements.js
+++ b/assets/js/gestion_traitements.js
@@ -1,0 +1,229 @@
+// Attend que le DOM soit entièrement chargé
+document.addEventListener('DOMContentLoaded', function () {
+
+    // Fonctions d'échappement HTML simples pour la sécurité XSS de base côté client
+    function escapeHTML(str) {
+        if (str === null || typeof str === 'undefined') return '';
+        return String(str).replace(/[&<>"']/g, function (match) {
+            return {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            }[match];
+        });
+    }
+
+    function escapeAttribute(str) {
+        // Pour les attributs HTML, en particulier les classes ou les URL simples.
+        // Une validation plus poussée est nécessaire pour les URL complexes ou les styles.
+        if (str === null || typeof str === 'undefined') return '';
+        return escapeHTML(String(str)); // Pour ce cas, escapeHTML est suffisant.
+                                     // Pour les URL dans href, encodeURIComponent pourrait être plus approprié sur les parties variables.
+    }
+
+    const traitementModal = new bootstrap.Modal(document.getElementById('traitementModal'));
+    const btnAjouterTraitement = document.getElementById('btnAjouterTraitement');
+    const formTraitement = document.getElementById('formTraitement');
+    const listeTraitementsBody = document.getElementById('listeTraitementsBody');
+    const messagesDiv = document.getElementById('messages');
+    let traitementIdField = document.getElementById('traitementId');
+
+    // Fonction pour afficher les messages
+    function afficherMessage(message, type = 'info') {
+        messagesDiv.innerHTML = `<div class="alert alert-${type}" role="alert">${message}</div>`;
+        setTimeout(() => { messagesDiv.innerHTML = ''; }, 5000);
+    }
+
+    // Charger la liste des traitements au chargement de la page
+    chargerTraitements();
+
+    // Ouvrir le modal pour un nouveau traitement
+    if (btnAjouterTraitement) {
+        btnAjouterTraitement.addEventListener('click', function () {
+            formTraitement.reset();
+            traitementIdField.value = ''; // Assure qu'il n'y a pas d'ID pour un ajout
+            document.getElementById('traitementModalLabel').textContent = 'Ajouter un Traitement';
+            traitementModal.show();
+        });
+    }
+
+    // Soumission du formulaire (Ajout/Modification)
+    if (formTraitement) {
+        formTraitement.addEventListener('submit', function (e) {
+            e.preventDefault();
+            sauvegarderTraitement();
+        });
+    }
+
+    // Fonction pour charger les traitements depuis le serveur
+    async function chargerTraitements() {
+        try {
+            // Remplacer par l'URL correcte du script PHP qui liste les traitements
+            const response = await fetch('traitement_lister.php');
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const traitements = await response.json();
+
+            listeTraitementsBody.innerHTML = ''; // Vider le tableau
+            if (traitements.length === 0) {
+                listeTraitementsBody.innerHTML = '<tr><td colspan="8" class="text-center">Aucun traitement trouvé.</td></tr>';
+                return;
+            }
+
+            traitements.forEach(trait => {
+                const row = listeTraitementsBody.insertRow();
+                // Attention XSS: Les données (trait.lib_trait, trait.description, etc.) sont insérées via innerHTML.
+                // Elles devraient être nettoyées côté serveur (déjà fait avec sanitize_input pour la plupart)
+                // ou échappées ici si elles peuvent contenir du HTML arbitraire.
+                // Pour trait.icone, s'assurer qu'il ne contient que des classes CSS valides.
+                row.innerHTML = `
+                    <td>${trait.id_trait}</td>
+                    <td>${escapeHTML(trait.lib_trait)}</td>
+                    <td>${escapeHTML(trait.description || '')}</td>
+                    <td>${escapeHTML(trait.url_traitement || '')}</td>
+                    <td><i class="${escapeAttribute(trait.icone || 'fas fa-file')}"></i> ${escapeHTML(trait.icone || '')}</td>
+                    <td>${trait.ordre_affichage}</td>
+                    <td>${trait.est_actif == 1 ? '<span class="badge bg-success">Oui</span>' : '<span class="badge bg-danger">Non</span>'}</td>
+                    <td>
+                        <button class="btn btn-sm btn-warning btn-modifier" data-id="${trait.id_trait}"><i class="fas fa-edit"></i> Modifier</button>
+                        <button class="btn btn-sm btn-danger btn-supprimer" data-id="${trait.id_trait}"><i class="fas fa-trash"></i> Supprimer</button>
+                    </td>
+                `;
+            });
+
+            // Attacher les écouteurs d'événements pour les nouveaux boutons
+            attacherEcouteursActions();
+
+        } catch (error) {
+            console.error('Erreur lors du chargement des traitements:', error);
+            listeTraitementsBody.innerHTML = '<tr><td colspan="8" class="text-center">Erreur lors du chargement des données.</td></tr>';
+            afficherMessage('Erreur lors du chargement des traitements. Vérifiez la console pour plus de détails.', 'danger');
+        }
+    }
+
+    // Fonction pour sauvegarder (ajouter ou modifier) un traitement
+    async function sauvegarderTraitement() {
+        const formData = new FormData(formTraitement);
+        const idTrait = formData.get('id_trait');
+        const url = idTrait ? 'traitement_modifier.php' : 'traitement_ajouter.php';
+
+        // S'assurer que est_actif est envoyé même si non coché
+        if (!formData.has('est_actif')) {
+            formData.set('est_actif', '0');
+        } else {
+            formData.set('est_actif', '1');
+        }
+
+        try {
+            const response = await fetch(url, {
+                method: 'POST',
+                body: formData
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`);
+            }
+
+            const result = await response.json();
+
+            if (result.success) {
+                afficherMessage(result.message || 'Traitement sauvegardé avec succès!', 'success');
+                traitementModal.hide();
+                chargerTraitements(); // Recharger la liste
+            } else {
+                afficherMessage(result.message || 'Erreur lors de la sauvegarde.', 'danger');
+            }
+        } catch (error) {
+            console.error('Erreur lors de la sauvegarde du traitement:', error);
+            afficherMessage(`Erreur: ${error.message}`, 'danger');
+        }
+    }
+
+    // Fonction pour charger les données d'un traitement pour modification
+    async function chargerTraitementPourModification(id) {
+        try {
+            // Assurez-vous que traitement_lister.php peut retourner un seul traitement par ID
+            const response = await fetch(`traitement_lister.php?id=${id}`);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const traitement = await response.json();
+
+            if (traitement && !traitement.error) { // Supposant que l'API retourne un objet traitement
+                document.getElementById('traitementId').value = traitement.id_trait;
+                document.getElementById('lib_trait').value = traitement.lib_trait;
+                document.getElementById('description').value = traitement.description || '';
+                document.getElementById('url_traitement').value = traitement.url_traitement || '';
+                document.getElementById('icone').value = traitement.icone || 'fas fa-file';
+                document.getElementById('ordre_affichage').value = traitement.ordre_affichage || 0;
+                document.getElementById('est_actif').checked = traitement.est_actif == 1;
+
+                document.getElementById('traitementModalLabel').textContent = 'Modifier le Traitement';
+                traitementModal.show();
+            } else {
+                afficherMessage(traitement.error || 'Traitement non trouvé.', 'danger');
+            }
+        } catch (error) {
+            console.error('Erreur lors du chargement du traitement pour modification:', error);
+            afficherMessage('Erreur lors du chargement des données du traitement.', 'danger');
+        }
+    }
+
+    // Fonction pour supprimer un traitement
+    async function supprimerTraitement(id) {
+        if (!confirm('Êtes-vous sûr de vouloir supprimer ce traitement ?')) {
+            return;
+        }
+
+        try {
+            const formData = new FormData();
+            formData.append('id_trait', id);
+
+            const response = await fetch('traitement_supprimer.php', {
+                method: 'POST',
+                body: formData
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`);
+            }
+
+            const result = await response.json();
+
+            if (result.success) {
+                afficherMessage(result.message || 'Traitement supprimé avec succès!', 'success');
+                chargerTraitements(); // Recharger la liste
+            } else {
+                afficherMessage(result.message || 'Erreur lors de la suppression.', 'danger');
+            }
+        } catch (error) {
+            console.error('Erreur lors de la suppression du traitement:', error);
+            afficherMessage(`Erreur: ${error.message}`, 'danger');
+        }
+    }
+
+    // Attacher les écouteurs d'événements pour les boutons Modifier/Supprimer
+    function attacherEcouteursActions() {
+        document.querySelectorAll('.btn-modifier').forEach(button => {
+            button.addEventListener('click', function () {
+                const id = this.dataset.id;
+                chargerTraitementPourModification(id);
+            });
+        });
+
+        document.querySelectorAll('.btn-supprimer').forEach(button => {
+            button.addEventListener('click', function () {
+                const id = this.dataset.id;
+                supprimerTraitement(id);
+            });
+        });
+    }
+
+    // Initialisation (si nécessaire pour des éléments qui ne sont pas encore dans le DOM au premier chargement)
+    // chargerTraitements(); // Déjà appelé plus haut
+});

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,29 @@
+<?php
+// Configuration de la base de données
+define('DB_HOST', 'localhost'); // ou votre hôte
+define('DB_NAME', 'votre_base_de_donnees'); // à remplacer
+define('DB_USER', 'votre_utilisateur_db'); // à remplacer
+define('DB_PASS', 'votre_mot_de_passe_db'); // à remplacer
+define('DB_CHARSET', 'utf8mb4');
+
+// Options PDO
+$pdo_options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+// Configuration du site (optionnel)
+define('SITE_URL', 'http://localhost/votre_projet/'); // à remplacer
+define('SITE_NAME', 'Gestion des Menus');
+
+// Activer l'affichage des erreurs pour le développement
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+
+// Démarrer la session si elle n'est pas déjà démarrée
+if (session_status() == PHP_SESSION_NONE) {
+    session_start();
+}
+?>

--- a/core/db_connect.php
+++ b/core/db_connect.php
@@ -1,0 +1,34 @@
+<?php
+// Inclure la configuration
+require_once __DIR__ . '/../config/config.php';
+
+/**
+ * Fonction pour établir une connexion à la base de données.
+ * @return PDO|null L'objet PDO en cas de succès, null sinon.
+ */
+function getPDOConnection() {
+    $dsn = "mysql:host=" . DB_HOST . ";dbname=" . DB_NAME . ";charset=" . DB_CHARSET;
+    try {
+        $pdo = new PDO($dsn, DB_USER, DB_PASS, $GLOBALS['pdo_options']);
+        return $pdo;
+    } catch (PDOException $e) {
+        // En production, logguer l'erreur plutôt que de l'afficher directement
+        error_log("Erreur de connexion à la base de données : " . $e->getMessage());
+        // Pour le développement, on peut afficher l'erreur
+        // die("Erreur de connexion à la base de données : " . $e->getMessage());
+        // Il serait préférable d'afficher une page d'erreur générique en production
+        // ou de gérer l'erreur d'une manière plus élégante.
+        return null;
+    }
+}
+
+// Exemple d'utilisation (peut être commenté ou supprimé après test)
+/*
+$pdo = getPDOConnection();
+if ($pdo) {
+    echo "Connexion à la base de données établie avec succès.";
+} else {
+    echo "Échec de la connexion à la base de données.";
+}
+*/
+?>

--- a/core/functions.php
+++ b/core/functions.php
@@ -1,0 +1,137 @@
+<?php
+// Fonctions utilitaires générales pour le projet
+
+/**
+ * Redirige vers une URL spécifiée.
+ * @param string $url L'URL de redirection.
+ */
+function redirect(string $url): void {
+    header("Location: " . $url);
+    exit;
+}
+
+/**
+ * Nettoie une chaîne de caractères pour éviter les failles XSS.
+ * @param string|null $data La chaîne à nettoyer.
+ * @return string La chaîne nettoyée.
+ */
+function sanitize_input(?string $data): string {
+    if ($data === null) {
+        return '';
+    }
+    $data = trim($data);
+    $data = stripslashes($data);
+    $data = htmlspecialchars($data, ENT_QUOTES, 'UTF-8');
+    return $data;
+}
+
+/**
+ * Vérifie si l'utilisateur est connecté et a un certain rôle.
+ * @param array $roles_autorises Array des rôles autorisés. Si vide, vérifie juste si connecté.
+ * @return bool True si autorisé, false sinon.
+ */
+function check_user_role(array $roles_autorises = []): bool {
+    if (!isset($_SESSION['user_id'])) {
+        return false; // Utilisateur non connecté
+    }
+    if (empty($roles_autorises)) {
+        return true; // Connecté, aucun rôle spécifique requis
+    }
+    if (isset($_SESSION['user_role']) && in_array($_SESSION['user_role'], $roles_autorises)) {
+        return true; // L'utilisateur a l'un des rôles requis
+    }
+    return false; // Rôle non autorisé
+}
+
+/**
+ * Définit un message flash en session.
+ * @param string $message Le message à afficher.
+ * @param string $type Le type de message (ex: 'success', 'danger', 'info').
+ */
+function set_flash_message(string $message, string $type = 'info'): void {
+    $_SESSION['flash_message'] = $message;
+    $_SESSION['flash_type'] = $type;
+}
+
+/**
+ * Affiche un message flash s'il existe et le supprime de la session.
+ * Utilisé directement dans le template ou via une fonction d'affichage.
+ * NOTE: Le header.php a déjà une logique pour afficher les messages flash.
+ * Cette fonction pourrait être utilisée si on veut un contrôle plus fin à d'autres endroits.
+ */
+function display_flash_message(): void {
+    if (isset($_SESSION['flash_message']) && isset($_SESSION['flash_type'])) {
+        echo "<div class='alert alert-" . htmlspecialchars($_SESSION['flash_type']) . " alert-dismissible fade show' role='alert'>";
+        echo htmlspecialchars($_SESSION['flash_message']);
+        echo "<button type='button' class='btn-close' data-bs-dismiss='alert' aria-label='Close'></button>";
+        echo "</div>";
+        unset($_SESSION['flash_message']);
+        unset($_SESSION['flash_type']);
+    }
+}
+
+/**
+ * Génère une réponse JSON standardisée.
+ * @param bool $success Statut de l'opération.
+ * @param string|null $message Message descriptif.
+ * @param array $data Données additionnelles à retourner.
+ * @param int $status_code Code de statut HTTP.
+ */
+function json_response(bool $success, ?string $message = null, array $data = [], int $status_code = 200): void {
+    header('Content-Type: application/json');
+    http_response_code($status_code);
+    $response = ['success' => $success];
+    if ($message !== null) {
+        $response['message'] = $message;
+    }
+    if (!empty($data)) {
+        $response['data'] = $data;
+    }
+    echo json_encode($response);
+    exit;
+}
+
+/**
+ * Tronque une chaîne de caractères à une longueur donnée et ajoute "..."
+ * @param string $text
+ * @param int $max_length
+ * @return string
+ */
+function truncate_text(string $text, int $max_length = 100): string {
+    if (mb_strlen($text) > $max_length) {
+        $text = mb_substr($text, 0, $max_length - 3) . '...';
+    }
+    return $text;
+}
+
+/**
+ * Vérifie si la requête actuelle est une requête POST.
+ * @return bool
+ */
+function is_post_request(): bool {
+    return $_SERVER['REQUEST_METHOD'] === 'POST';
+}
+
+/**
+ * Vérifie si la requête actuelle est une requête GET.
+ * @return bool
+ */
+function is_get_request(): bool {
+    return $_SERVER['REQUEST_METHOD'] === 'GET';
+}
+
+// TODO - SÉCURITÉ : Implémenter la protection CSRF
+// Pour cela, il faudrait :
+// 1. Une fonction pour générer un token CSRF et le stocker en session.
+//    Ex: generate_csrf_token()
+// 2. Une fonction pour valider un token CSRF soumis avec un formulaire.
+//    Ex: validate_csrf_token($submitted_token)
+// 3. Inclure le token CSRF comme champ caché dans tous les formulaires qui modifient l'état (POST).
+//    <input type="hidden" name="csrf_token" value="<?php echo generate_csrf_token(); ?>">
+// 4. Vérifier le token au début des scripts PHP qui traitent ces formulaires.
+//    if (!validate_csrf_token($_POST['csrf_token'])) { /* Erreur ou rejet */ }
+
+// Vous pouvez ajouter d'autres fonctions utilitaires ici au besoin.
+// Par exemple, des fonctions pour la pagination, la gestion des dates, etc.
+
+?>

--- a/includes/sidebar.php
+++ b/includes/sidebar.php
@@ -1,0 +1,44 @@
+<?php
+// Ce fichier est destiné à être inclus dans la structure principale de la page.
+
+// Assurer la connexion à la BD et la disponibilité du générateur
+// Ces require_once sont importants si sidebar.php est inclus
+// dans un contexte où ils ne sont pas déjà chargés.
+// Cependant, si header.php les charge déjà, ils pourraient être redondants (mais inoffensifs).
+require_once __DIR__ . '/../config/config.php'; // Pour SITE_URL, et potentiellement la session
+require_once __DIR__ . '/../core/db_connect.php';   // Pour getPDOConnection()
+require_once __DIR__ . '/sidebar_generateur.php'; // Pour generer_menu_sidebar()
+
+$pdo_sidebar = getPDOConnection(); // Obtenir une instance PDO
+
+if (!$pdo_sidebar) {
+    // Gérer l'erreur de connexion à la BD si elle n'a pas pu être établie
+    // Peut-être afficher un message d'erreur discret ou rien du tout.
+    // echo "<div class='alert alert-danger'>Erreur de connexion BD pour la sidebar.</div>";
+    // Normalement, db_connect.php gère déjà le logging ou die() en cas d'échec critique.
+} else {
+    // Appeler la fonction pour générer le menu de la sidebar
+    // La fonction generer_menu_sidebar() est dans sidebar_generateur.php
+    // Elle utilise $_SESSION['id_gu'] pour identifier le groupe de l'utilisateur.
+    // Assurez-vous que la session est démarrée (normalement fait dans config.php ou header.php)
+    // et que $_SESSION['id_gu'] est défini après la connexion de l'utilisateur.
+
+    $sidebar_html = generer_menu_sidebar($pdo_sidebar);
+
+    // Afficher le HTML de la sidebar
+    // Vous pouvez entourer cela d'une structure de sidebar (ex: <nav id="sidebar">)
+    // La fonction generer_menu_sidebar retourne déjà un <ul>.
+
+    // Exemple de structure de base pour une sidebar Bootstrap 5
+    // Cette structure serait typiquement dans le fichier qui inclut sidebar.php (ex: header.php ou un template de page)
+    // Pour l'instant, on affiche directement le contenu généré.
+    // Si la sidebar est une <nav> dans une colonne Bootstrap :
+    // <div class="col-md-3 col-lg-2 d-md-block bg-light sidebar collapse" id="sidebarMenu">
+    //   <div class="position-sticky pt-3">
+    //      <?php echo $sidebar_html; (le ul généré) >
+    //   </div>
+    // </div>
+
+    echo $sidebar_html;
+}
+?>

--- a/includes/sidebar_generateur.php
+++ b/includes/sidebar_generateur.php
@@ -1,0 +1,126 @@
+<?php
+// Ce fichier ne devrait pas être accessible directement via URL.
+// Il est destiné à être inclus par d'autres scripts PHP.
+
+/**
+ * Génère le HTML pour la sidebar de l'utilisateur connecté.
+ *
+ * @param PDO $pdo L'objet de connexion PDO.
+ * @return string Le HTML de la sidebar, ou une chaîne vide si aucune permission ou erreur.
+ */
+function generer_menu_sidebar(PDO $pdo): string {
+    $html_sidebar = "";
+
+    // 1. Récupérer l'ID du groupe de l'utilisateur connecté (simulation)
+    // En réalité, cela viendrait d'une session après authentification.
+    // Exemple: $id_gu_utilisateur = $_SESSION['id_gu'] ?? null;
+
+    // Pour les tests, on peut forcer un id_gu. Supprimez ou commentez en production.
+    if (isset($_SESSION['id_gu'])) {
+        $id_gu_utilisateur = (int)$_SESSION['id_gu'];
+    } else {
+        // Si vous voulez tester sans session, décommentez la ligne suivante avec un ID de groupe valide.
+        // $id_gu_utilisateur = 1; // Exemple: ID du groupe admin ou un autre groupe de test
+        // return "<ul class='nav flex-column'><li class='nav-item'><span class='nav-link text-warning'>ID Groupe Utilisateur non défini en session.</span></li></ul>";
+        return ""; // Pas de sidebar si pas d'ID de groupe
+    }
+
+    if (!$id_gu_utilisateur) {
+        // Pas d'utilisateur connecté ou pas de groupe associé.
+        // Vous pourriez retourner un menu par défaut ou un message.
+        return "<ul class='nav flex-column'><li class='nav-item'><span class='nav-link text-muted'>Non connecté</span></li></ul>";
+    }
+
+    try {
+        // 2. Interroger la base de données
+        $sql = "SELECT t.lib_trait, t.url_traitement, t.icone
+                FROM traitement t
+                JOIN rattacher r ON t.id_trait = r.id_traitement
+                WHERE r.id_gu = :id_gu_utilisateur
+                  AND r.voir_dans_sidebar = TRUE
+                  AND t.est_actif = TRUE  -- On ne montre que les traitements globalement actifs
+                ORDER BY t.ordre_affichage ASC, t.lib_trait ASC";
+
+        $stmt = $pdo->prepare($sql);
+        $stmt->bindParam(':id_gu_utilisateur', $id_gu_utilisateur, PDO::PARAM_INT);
+        $stmt->execute();
+
+        $menu_items = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        // 3. Générer le HTML
+        // Utilisation de classes Bootstrap pour la sidebar (exemple)
+        $html_sidebar .= "<ul class='nav flex-column'>"; // Classe 'sidebar-nav' ou autre de votre CSS
+
+        if (empty($menu_items)) {
+            // $html_sidebar .= "<li class='nav-item'><span class='nav-link text-muted'>Aucun menu disponible.</span></li>";
+            // Ou ne rien afficher si aucun item
+        } else {
+            $site_url_base = defined('SITE_URL') ? rtrim(SITE_URL, '/') : '';
+
+            foreach ($menu_items as $item) {
+                $url = !empty($item['url_traitement']) ? htmlspecialchars($item['url_traitement']) : '#';
+                // S'assurer que l'URL est correctement formée (absolue ou relative à la racine du site)
+                if ($url !== '#' && !filter_var($url, FILTER_VALIDATE_URL) && strpos($url, '/') !== 0) {
+                    // Si ce n'est pas une URL absolue et ne commence pas par '/', la préfixer avec SITE_URL
+                    $url = $site_url_base . '/' . ltrim($url, '/');
+                } else if ($url !== '#' && strpos($url, '/') === 0 && defined('SITE_URL')) {
+                    // Si commence par / mais n'est pas une URL complète (ex: /admin/page.php)
+                    // On la combine avec la partie host de SITE_URL
+                    $parsed_site_url = parse_url(SITE_URL);
+                    $base_for_relative = $parsed_site_url['scheme'] . '://' . $parsed_site_url['host'];
+                    if(isset($parsed_site_url['port'])) $base_for_relative .= ':' . $parsed_site_url['port'];
+                    // $url = $base_for_relative . $url; // Ceci peut être trop si SITE_URL contient déjà un path.
+                    // Plus simple: si url commence par /, on suppose qu'elle est relative à la racine du domaine.
+                    // Si SITE_URL a un sous-dossier, il faut être prudent.
+                    // Pour l'instant, on assume que les URL commençant par / sont correctes ou que SITE_URL est la racine du domaine.
+                    // Si SITE_URL est http://localhost/monprojet/, et url est /page.php, on veut http://localhost/monprojet/page.php
+                    // Si url est page.php, on veut http://localhost/monprojet/page.php
+                    // Si url est http://example.com/page.php, on la laisse telle quelle.
+                    if (strpos($url, '/') === 0 && $site_url_base !== '') { // url = /admin/users.php, site_url_base = http://localhost/myapp
+                         $url = $site_url_base . $url; // -> http://localhost/myapp/admin/users.php
+                    }
+
+                }
+
+
+                $icone_html = !empty($item['icone']) ? "<i class='" . htmlspecialchars($item['icone']) . " me-2'></i>" : "";
+
+                $html_sidebar .= "<li class='nav-item'>";
+                $html_sidebar .= "<a class='nav-link' href='" . $url . "'>";
+                $html_sidebar .= $icone_html . htmlspecialchars($item['lib_trait']);
+                $html_sidebar .= "</a></li>";
+            }
+        }
+        $html_sidebar .= "</ul>";
+
+    } catch (PDOException $e) {
+        error_log("Erreur PDO Sidebar: " . $e->getMessage());
+        // En production, ne pas afficher l'erreur SQL directement.
+        $html_sidebar = "<ul class='nav flex-column'><li class='nav-item'><span class='nav-link text-danger'>Erreur chargement menu.</span></li></ul>";
+    } catch (Exception $e) {
+        error_log("Erreur Générale Sidebar: " . $e->getMessage());
+        $html_sidebar = "<ul class='nav flex-column'><li class='nav-item'><span class='nav-link text-danger'>Erreur interne menu.</span></li></ul>";
+    }
+
+    return $html_sidebar;
+}
+
+// Pour tester cette fonction directement (à commenter/supprimer en production)
+/*
+if (php_sapi_name() === 'cli' || (isset($_GET['test_sidebar']) && $_GET['test_sidebar'] == '1')) {
+    require_once __DIR__ . '/../config/config.php'; // Pour SITE_URL etc.
+    require_once __DIR__ . '/../core/db_connect.php'; // Pour getPDOConnection
+
+    $pdo_test = getPDOConnection();
+    if ($pdo_test) {
+        // Simuler une session pour le test
+        $_SESSION['id_gu'] = 1; // Remplacer par un ID de groupe valide dans votre BD
+
+        echo "<h3>Test de la Sidebar Générée :</h3>";
+        echo generer_menu_sidebar($pdo_test);
+    } else {
+        echo "Impossible de se connecter à la base de données pour le test.";
+    }
+}
+*/
+?>


### PR DESCRIPTION
Ce commit introduit un système complet pour la gestion des menus (traitements) et des permissions associées par groupe d'utilisateurs.

Fonctionnalités clés :
- CRUD complet pour les 'traitements' (éléments de menu/pages).
- Interface d'administration pour lister, ajouter, modifier, supprimer les traitements.
- Interface d'administration pour assigner des permissions granulaires (voir sidebar, ajouter, modifier, supprimer, imprimer, exporter, importer) sur chaque traitement à des groupes d'utilisateurs spécifiques.
- Génération dynamique de la sidebar utilisateur basée sur les permissions du groupe auquel il appartient.
- Structure de base PHP, JS, CSS pour l'application.
- Fonctions utilitaires pour la connexion BD, la sanitization, les réponses JSON.
- Points d'attention pour la sécurité (XSS, CSRF, autorisation) identifiés et partiellement adressés (échappement HTML de base, placeholders pour autorisation).

Les fichiers `includes/header.php` et `includes/footer.php` n'ont pas pu être modifiés par l'agent en raison de problèmes techniques, leur vérification et intégration manuelle pourraient être nécessaires.